### PR TITLE
[+] signature with picture [+] second company logo

### DIFF
--- a/template/example-report.tex
+++ b/template/example-report.tex
@@ -31,6 +31,7 @@
 \def\reportCompanyCity{code postal, VILLE} % Adresse (cont.) de l'entreprise
 \def\reportCompanyPhone{téléphone} % Téléphone de l'entreprise
 \def\reportCompanyLogoPath{figures/anonymous_company-logo} % Logo de l'entreprise -- comment this definition to remove company logo
+%\def\reportSecondCompanyLogoPath{figures/logo.png} % Deuxième logo d'entreprise si besoin
 
 \def\place{Winterfell} % Ville pour la signature pour l'engagement anti-plagiat
 \def\date{\today} % Date pour la signature de l'engagement anti-plagiat
@@ -41,8 +42,8 @@
 \maketitle
 \pagenumbering{roman}
 
-\insertAntiPlagiarismAgreement{Snow, Jon}{2014041022}
-
+\insertAntiPlagiarismAgreement{Snow, Jon}{2014041022}{figures/anonymous_company-logo}{0.2}
+                            % {Nom, Prénom}{n°étu}{image signature}{scale signature} 
 % You may insert several agreement in case of multiple authors
 %\insertAntiPlagiarismAgreement{Tarly, Samwell}{2014031142}
 

--- a/template/tnreport.cls
+++ b/template/tnreport.cls
@@ -127,6 +127,9 @@
 \def\includeCompanyLogo{%
   \@ifundefined{reportCompanyLogoPath}{}{\includegraphics[height=6em]{\reportCompanyLogoPath}}
 }
+\def\includeSecondCompanyLogo{%
+  \@ifundefined{reportSecondCompanyLogoPath}{}{\includegraphics[height=6em]{\reportSecondCompanyLogoPath}}
+}
 
 %below split between langs is mostly cosmetic
 \ifbool{english}{
@@ -333,7 +336,7 @@
 
 
 \makeatletter
-\newcommand\insertAntiPlagiarismAgreement[2]{%
+\newcommand\insertAntiPlagiarismAgreement[4]{%
 
   \begin{center} %Maybe one should makes an english version of this... TODO?
     \Large \bf Déclaration sur l'honneur de non-plagiat
@@ -385,7 +388,15 @@
 
   \hspace{5cm}{\bf Fait à \place{},     le  \date{}}
 
-  \hspace{5cm}{\bf Signature :}
+  \hspace{5cm}\begin{minipage}{0.3\textwidth}
+{\bf Signature :}
+\end{minipage}
+\begin{minipage}{0.6\textwidth}\raggedright
+\includegraphics[scale=#4]{#3}
+\\
+\end{minipage}
+\noindent
+
 \cleardoublepage
 }
 \makeatother
@@ -457,7 +468,7 @@
 \reportAuthorEmail{} \\
 \smallskip
 
-\reportSchool{}\\
+\reportSchool{} \hfill\smash{\raisebox{-0.5\normalbaselineskip}{\includeSecondCompanyLogo{}}}\\
 \reportSchoolAddress{},\\
 \reportSchoolCity{}\\
 \reportSchoolPhone{}\\
@@ -468,7 +479,7 @@
 \reportCompany{}\\
 \reportCompanyAddress{}\\
 \reportCompanyCity{}\\
-\reportCompanyPhone{}  \hfill\smash{\raisebox{-0.5\normalbaselineskip}{\includeCompanyLogo{}}}%maybe you will need to modifie this line to suites better to the compagny logo size
+\reportCompanyPhone{}  \hfill\smash{\raisebox{-0.5\normalbaselineskip}{\includeCompanyLogo{}}}%maybe you will need to modify this line to suites better to the compagny logo size
 
 
 \medskip


### PR DESCRIPTION
Mettre une signature dans la déclaration de non-plagiat n'était pas pris en compte dans la dernière version du template, cela devrait résoudre le problème.
Aussi on m'a demandé d'ajouter la possibilité de mettre un deuxième logo pour l'entreprise, ce qui est chose faite.