### PR TITLE
Overleaf Glossaries make issue solved

### DIFF
--- a/template/tnreport.cls
+++ b/template/tnreport.cls
@@ -75,7 +75,7 @@
 \RequirePackage{acronym}
 
 
-\RequirePackage{glossaries-extra} %use this instead of "glossaries" for better looking glossaries
+\RequirePackage[automake]{glossaries-extra} %use this instead of "glossaries" for better looking glossaries
 \makeglossaries
 
 %only loads the draftwatermark package if it is needed


### PR DESCRIPTION
Changed the glossaries-extra require package.
By adding automake option, Overleaf makes the glossaries correctly.